### PR TITLE
Add: blacklight_lando

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,20 @@
+---
+name: blacklight
+services:
+  test_solr:
+    type: solr:8.4
+    portforward: true
+    core: blacklight-core-test
+    config:
+      dir: "solr/conf"
+  development_solr:
+    type: solr:8.4
+    portforward: true
+    core: blacklight-core-dev
+    config:
+      dir: "solr/conf"
+proxy:
+  test_solr:
+    - blacklight.test.solr.lndo.site:8983
+  development_solr:
+    - blacklight.dev.solr.lndo.site:8983

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem "geoblacklight", "~> 4.0"
 gem "sprockets", "< 4.0"
 
 group :development, :test do
-  gem "solr_wrapper", ">= 0.3"
+  gem "blacklight_lando", "~> 0.3.0"
 end
 gem "rsolr", ">= 1.0", "< 3"
 gem "bootstrap", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7.2)
       view_component (>= 2.66, < 4)
+    blacklight_lando (0.3.1)
+      blacklight (>= 7.0)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     bootstrap (4.6.2)
@@ -130,7 +132,6 @@ GEM
       warden (~> 1.2.3)
     devise-guests (0.8.3)
       devise
-    domain_name (0.6.20240107)
     drb (2.2.1)
     dry-cli (1.0.0)
     erubi (1.12.0)
@@ -145,9 +146,6 @@ GEM
     faraday-retry (2.2.1)
       faraday (~> 2.0)
     ffi (1.16.3)
-    ffi-compiler (1.3.2)
-      ffi (>= 1.15.5)
-      rake
     geo_combine (0.9.0)
       activesupport
       faraday-net_http_persistent (~> 2.0)
@@ -183,15 +181,6 @@ GEM
       sprockets (>= 2.0.0)
       tilt (>= 1.2)
     hashdiff (1.1.0)
-    http (5.2.0)
-      addressable (~> 2.8)
-      base64 (~> 0.1)
-      http-cookie (~> 1.0)
-      http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.5.0)
-    http-cookie (1.0.5)
-      domain_name (~> 0.5)
-    http-form_data (2.3.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
@@ -223,9 +212,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    llhttp-ffi (0.5.0)
-      ffi-compiler (~> 1.0)
-      rake (~> 13.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -242,7 +228,6 @@ GEM
     mime-types-data (3.2024.0507)
     mini_mime (1.1.5)
     mini_portile2 (2.8.6)
-    minitar (0.9)
     minitest (5.22.3)
     msgpack (1.7.2)
     mutex_m (0.2.0)
@@ -330,7 +315,6 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    retriable (3.1.2)
     rexml (3.2.6)
     rgeo (3.0.1)
     rgeo-geojson (2.1.1)
@@ -338,7 +322,6 @@ GEM
     rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
-    ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
     sanitize (6.1.0)
       crass (~> 1.0.2)
@@ -356,11 +339,6 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    solr_wrapper (4.0.2)
-      http
-      minitar
-      retriable
-      ruby-progressbar
     sprockets (3.7.3)
       base64
       concurrent-ruby (~> 1.0)
@@ -424,6 +402,7 @@ PLATFORMS
 
 DEPENDENCIES
   blacklight (~> 7.0)
+  blacklight_lando (~> 0.3.0)
   bootsnap
   bootstrap (~> 4.0)
   capybara
@@ -440,7 +419,6 @@ DEPENDENCIES
   rsolr (>= 1.0, < 3)
   sassc-rails (~> 2.1)
   selenium-webdriver
-  solr_wrapper (>= 0.3)
   sprockets (< 4.0)
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,27 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+GeoBlacklight Development
 
-Things you may want to cover:
+## Quick Start
 
-* Ruby version
+### Steps
 
-* System dependencies
+#### 1. Start Solr
+```bash
+lando start
+```
+[Solr running at http://localhost:54701](http://localhost:54701)
 
-* Configuration
+#### 2. Start Rails
 
-* Database creation
+```bash
+bin/rails s
+```
 
-* Database initialization
+[Rails running at http://localhost:3000](http://localhost:3000)
 
-* How to run the test suite
+#### 3. Harvest GeoBlacklight Docs
 
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+```bash
+bin/rails geoblacklight:index:seed[remote]
+```

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,10 +1,13 @@
-load_defaults: 7.37.0
+load_defaults: 7.19.2
 development:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+  url: <%= ENV['SOLR_URL'] || ENV['lando_development_solr'] %>
 test: &test
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+  url: <%= ENV['SOLR_URL'] ||  ENV['lando_test_solr'] %>
 production:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+  url: <%= ENV['SOLR_URL'] %>
+staging:
+  adapter: solr
+  url: <%= ENV['SOLR_URL'] %>

--- a/config/initializers/lando_env.rb
+++ b/config/initializers/lando_env.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+if Rails.env.development? || Rails.env.test?
+  begin
+    lando_info = `lando info --format json`
+    lando_services = JSON.parse(lando_info, symbolize_names: true)
+    lando_services.each do |service|
+      case service[:service]
+      when "test_solr"
+        ENV["lando_test_solr"] = "http://#{service[:external_connection][:host]}:#{service[:external_connection][:port]}/solr/#{service[:core]}"
+      when "development_solr"
+        ENV["lando_development_solr"] = "http://#{service[:external_connection][:host]}:#{service[:external_connection][:port]}/solr/#{service[:core]}"
+      end
+      next unless service[:creds]
+
+      service[:creds].each do |key, value|
+        ENV["lando_#{service[:service]}_creds_#{key}"] = value
+      end
+    end
+  rescue StandardError
+    nil
+  end
+end


### PR DESCRIPTION
This PR adds the [blacklight_lando](https://rubygems.org/gems/blacklight_lando) gem to the application and ran the blacklight_lando generator: 

### Dependencies

This requires [Lando](https://lando.dev/). Installation instructions are online here: [Get Lando](https://lando.dev/download/).

### Run Solr

To run Solr via Lando just run the command below in the project's root directory:

```bash
lando start
```

Solr will now be running at http://localhost:54701

