### PR TITLE
Add: blacklight_allmaps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,9 +69,7 @@ gem "blacklight", "~> 7.0"
 gem "geoblacklight", "~> 4.0"
 gem "sprockets", "< 4.0"
 
-group :development, :test do
-  gem "blacklight_lando", "~> 0.3.0"
-end
+
 gem "rsolr", ">= 1.0", "< 3"
 gem "bootstrap", "~> 4.0"
 gem "twitter-typeahead-rails", "0.11.1.pre.corejavascript"
@@ -80,3 +78,11 @@ gem "jquery-rails"
 gem "devise"
 gem "devise-guests", "~> 0.8"
 gem "vite_rails", "~> 3.0"
+
+# GBL DEV 
+group :development, :test do
+  gem "solr_wrapper", ">= 0.3"
+  gem "blacklight_lando", "~> 0.3.0"
+end
+
+gem "blacklight_allmaps", "~> 0.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,9 @@ GEM
       ostruct (>= 0.3.2)
       rails (>= 5.1, < 7.2)
       view_component (>= 2.66, < 4)
+    blacklight_allmaps (0.4.0)
+      blacklight (>= 7.25.2, < 9)
+      httparty (~> 0.20)
     blacklight_lando (0.3.1)
       blacklight (>= 7.0)
     bootsnap (1.18.3)
@@ -117,6 +120,7 @@ GEM
       deep_merge (~> 1.2, >= 1.2.1)
     connection_pool (2.4.1)
     crass (1.0.6)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -132,6 +136,7 @@ GEM
       warden (~> 1.2.3)
     devise-guests (0.8.3)
       devise
+    domain_name (0.6.20240107)
     drb (2.2.1)
     dry-cli (1.0.0)
     erubi (1.12.0)
@@ -146,6 +151,9 @@ GEM
     faraday-retry (2.2.1)
       faraday (~> 2.0)
     ffi (1.16.3)
+    ffi-compiler (1.3.2)
+      ffi (>= 1.15.5)
+      rake
     geo_combine (0.9.0)
       activesupport
       faraday-net_http_persistent (~> 2.0)
@@ -181,6 +189,19 @@ GEM
       sprockets (>= 2.0.0)
       tilt (>= 1.2)
     hashdiff (1.1.0)
+    http (5.2.0)
+      addressable (~> 2.8)
+      base64 (~> 0.1)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.5.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
@@ -212,6 +233,9 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    llhttp-ffi (0.5.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -228,8 +252,11 @@ GEM
     mime-types-data (3.2024.0507)
     mini_mime (1.1.5)
     mini_portile2 (2.8.6)
+    minitar (0.9)
     minitest (5.22.3)
     msgpack (1.7.2)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
@@ -315,6 +342,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    retriable (3.1.2)
     rexml (3.2.6)
     rgeo (3.0.1)
     rgeo-geojson (2.1.1)
@@ -322,6 +350,7 @@ GEM
     rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
+    ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
     sanitize (6.1.0)
       crass (~> 1.0.2)
@@ -339,6 +368,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    solr_wrapper (4.0.2)
+      http
+      minitar
+      retriable
+      ruby-progressbar
     sprockets (3.7.3)
       base64
       concurrent-ruby (~> 1.0)
@@ -402,6 +436,7 @@ PLATFORMS
 
 DEPENDENCIES
   blacklight (~> 7.0)
+  blacklight_allmaps (~> 0.4.0)
   blacklight_lando (~> 0.3.0)
   bootsnap
   bootstrap (~> 4.0)
@@ -419,6 +454,7 @@ DEPENDENCIES
   rsolr (>= 1.0, < 3)
   sassc-rails (~> 2.1)
   selenium-webdriver
+  solr_wrapper (>= 0.3)
   sprockets (< 4.0)
   sprockets-rails
   sqlite3 (~> 1.4)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
-# README
-
-GeoBlacklight Development
+# GeoBlacklight Development
 
 ## Quick Start
 
+* GeoBlacklight v4.4
+* BlacklightLando v0.3.0
+* Blacklight::Allmaps v0.4.0
+
 ### Steps
 
-#### 1. Start Solr
+#### 1. Clone this Repository
+
+```bash
+git clone https://github.com/ewlarson/gbl-dev.git
+cd gbl-dev
+```
+
+#### 2. Start Solr
+
 ```bash
 lando start
 ```
+
 [Solr running at http://localhost:54701](http://localhost:54701)
 
-#### 2. Start Rails
+#### 3. Start Rails
 
 ```bash
 bin/rails s
@@ -20,8 +31,31 @@ bin/rails s
 
 [Rails running at http://localhost:3000](http://localhost:3000)
 
-#### 3. Harvest GeoBlacklight Docs
+#### 4. Harvest GeoBlacklight Docs
+
+From GeoBlacklight
 
 ```bash
 bin/rails geoblacklight:index:seed[remote]
 ```
+
+#### 5. Blacklight::Allmaps Steps
+
+Harvest fixtures from Blacklight::Allmaps
+
+```bash
+SOLR_URL=http://localhost:54701/solr/blacklight-core-dev LIGHT=geoblacklight bin/rails blacklight_allmaps:index:gbl_fixtures
+```
+
+Harvest IIIF Annotations
+
+```bash
+bin/rails blacklight_allmaps:sidecars:harvest:allmaps
+```
+
+Populate the Georeferenced Facet
+
+```bash
+bin/rails blacklight_allmaps:index:georeferenced_facet
+```
+

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,4 @@ require_relative "config/application"
 Rails.application.load_tasks
 
 require 'solr_wrapper/rake_task' unless Rails.env.production?
+require 'blacklight/allmaps/rake_task'

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,5 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
+//= link 'application.css'
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
+//= link blacklight/allmaps/allmaps-logo.svg

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,9 @@
 //= require bootstrap
 //= require blacklight/blacklight
 
+    // Required by Blacklight::Allmaps
+    //= require blacklight-allmaps/app/assets/javascripts/blacklight/allmaps/blacklight-allmaps.js
+
 
 
 // Required by GeoBlacklight

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,4 @@
 @import 'bootstrap';
 @import 'blacklight';
 @import 'geoblacklight';
+@import 'blacklight/allmaps/base';

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -7,6 +7,10 @@ class CatalogController < ApplicationController
     # Please see https://github.com/projectblacklight/blacklight/pull/2006/
     config.raw_endpoint.enabled = true
 
+    # Blacklight::Allmaps Viewer
+    config.default_solr_unique_key = "id"
+    config.default_georeferenced_field = "gbl_georeferenced_b"
+
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     ## @see https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html
     ## @see https://lucene.apache.org/solr/guide/6_6/the-dismax-query-parser.html#TheDisMaxQueryParser-Theq.altParameter
@@ -45,7 +49,10 @@ class CatalogController < ApplicationController
     config.show.display_type_field = "format"
     config.show.partials.delete(:show)
     config.show.partials << "show_default_display_note"
-    config.show.partials << "show_default_viewer_container"
+    ###config.show.partials << "show_default_viewer_container"
+
+    # Blacklight::Allmaps Tabbed Viewer
+    config.show.partials << "show_allmaps_tabbed_viewer_container"
     config.show.partials << "show_default_attribute_table"
     config.show.partials << "show_default_viewer_information"
     config.show.partials << :show

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -20,4 +20,18 @@ class SolrDocument
   # and Blacklight::Document::SemanticFields#to_semantic_values
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
+  
+  def sidecar_allmaps
+    # Find or create, and set version
+    sidecar = Blacklight::Allmaps::Sidecar.where(
+      solr_document_id: id,
+    ).first_or_create do |sc|
+      sc.solr_version = self._source["_version_"]
+    end
+
+    sidecar.solr_version = self._source["_version_"]
+    sidecar.save
+
+    sidecar
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,12 +2,16 @@ require_relative "boot"
 
 require "rails/all"
 
+
+require "blacklight/allmaps/engine"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module GblDev
   class Application < Rails::Application
+
+    config.railties_order = [Blacklight::Allmaps::Engine, :main_app, :all]
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,7 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.active_job.queue_adapter = :inline
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,7 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "leaflet", to: "https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js", preload: true
+pin "leaflet-fullscreen", to: "https://cdn.jsdelivr.net/npm/leaflet-fullscreen@1.0.2/dist/Leaflet.fullscreen.min.js", preload: true
+pin "@allmaps/leaflet", to: "https://cdn.jsdelivr.net/npm/@allmaps/leaflet/dist/bundled/allmaps-leaflet-1.9.umd.js", preload: true
+pin_all_from File.expand_path("../app/javascript/blacklight/allmaps", __dir__), under: "blacklight-allmaps"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,3 +14,8 @@ Rails.application.config.assets.version = "1.0"
 Rails.application.config.assets.precompile += %w( favicon.ico )
 
 Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'images')
+
+          # Blacklight Allmaps
+          Rails.application.config.assets.paths << Rails.root.join('node_modules')
+          Rails.application.config.assets.paths << Rails.root.join('vendor', 'assets', 'images')
+          Rails.application.config.assets.precompile += %w( blacklight/allmaps/allmaps-logo.svg )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,4 +43,5 @@ mount Geoblacklight::Engine => 'geoblacklight'
           concerns :gbl_downloadable
         end
         resources :download, only: [:show]
+mount Blacklight::Allmaps::Engine => '/'
 end

--- a/db/migrate/20240514161028_create_solr_document_sidecar_allmaps.blacklight_allmaps_engine.rb
+++ b/db/migrate/20240514161028_create_solr_document_sidecar_allmaps.blacklight_allmaps_engine.rb
@@ -1,0 +1,16 @@
+# This migration comes from blacklight_allmaps_engine (originally 20240307155110)
+class CreateSolrDocumentSidecarAllmaps < ActiveRecord::Migration[7.0]
+  def change
+    create_table :blacklight_allmaps_sidecars do |t|
+      t.string :solr_document_id, index: true
+      t.string :document_type, default: "SolrDocument"
+      t.string :manifest_id, index: true
+      t.boolean :annotated, default: false
+      t.string :allmaps_id, index: true
+      t.text :iiif_manifest
+      t.text :allmaps_annotation
+      t.bigint :solr_version
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_14_153250) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_14_161028) do
+  create_table "blacklight_allmaps_sidecars", force: :cascade do |t|
+    t.string "solr_document_id"
+    t.string "document_type", default: "SolrDocument"
+    t.string "manifest_id"
+    t.boolean "annotated", default: false
+    t.string "allmaps_id"
+    t.text "iiif_manifest"
+    t.text "allmaps_annotation"
+    t.bigint "solr_version"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["allmaps_id"], name: "index_blacklight_allmaps_sidecars_on_allmaps_id"
+    t.index ["manifest_id"], name: "index_blacklight_allmaps_sidecars_on_manifest_id"
+    t.index ["solr_document_id"], name: "index_blacklight_allmaps_sidecars_on_solr_document_id"
+  end
+
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "user_type"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "@geoblacklight/frontend": "^4.4"
+    "@geoblacklight/frontend": "^4.4",
+    "blacklight-allmaps": "^0.3.1"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,93 @@
 # yarn lockfile v1
 
 
+"@allmaps/annotation@^1.0.0-beta.26":
+  version "1.0.0-beta.26"
+  resolved "https://registry.yarnpkg.com/@allmaps/annotation/-/annotation-1.0.0-beta.26.tgz#c0fbaeddc305d28122284686db75e46ea43f0d41"
+  integrity sha512-1gVsLXL8mYwf0qW4tIxqDi9Mg4jUcEzeAwvqrRH55Js6RNxZfzGAPLIRdHgu/TBMUxKlJ2tuv3WyUpXfspJHSA==
+  dependencies:
+    zod "^3.22.4"
+
+"@allmaps/id@^1.0.0-beta.26":
+  version "1.0.0-beta.26"
+  resolved "https://registry.yarnpkg.com/@allmaps/id/-/id-1.0.0-beta.26.tgz#42f19d5a76d0407c94d0208b8fe464468c2a8b71"
+  integrity sha512-VmQLtJuBThFlPdKmb+5BzDvWguOlSLQQyJNFwqCp/09/PfPRVDia4fma/NJE3K3dKEvGacB6xiUOvIoVDAAlqw==
+  dependencies:
+    "@allmaps/types" "^1.0.0-beta.12"
+
+"@allmaps/iiif-parser@^1.0.0-beta.36":
+  version "1.0.0-beta.36"
+  resolved "https://registry.yarnpkg.com/@allmaps/iiif-parser/-/iiif-parser-1.0.0-beta.36.tgz#8cd0466cd97532a5c73ffc8001d11710d93338b2"
+  integrity sha512-sXOuwSeyOGRBEaYBqTyAIPPPolFO0pDN6WvPvup5m7A82TBRfErpwVwcCqHd+kyncRV1E5/Y3/zkyJIyEurU9A==
+  dependencies:
+    "@allmaps/types" "^1.0.0-beta.12"
+    zod "^3.22.4"
+
+"@allmaps/leaflet@^1.0.0-beta.33":
+  version "1.0.0-beta.33"
+  resolved "https://registry.yarnpkg.com/@allmaps/leaflet/-/leaflet-1.0.0-beta.33.tgz#ca401f8182e3dee7d9f768595742c32393770914"
+  integrity sha512-dhnuwWBkIyU0czgqjukIpIOeKhCHDX8fCkCqD1UMXq2u5yiZWpNdhq0fwj3j9xYA8V4aIUgRntM3YFiDzXzolg==
+  dependencies:
+    "@allmaps/annotation" "^1.0.0-beta.26"
+    "@allmaps/render" "^1.0.0-beta.61"
+    "@allmaps/stdlib" "^1.0.0-beta.27"
+    "@allmaps/transform" "^1.0.0-beta.37"
+    "@allmaps/types" "^1.0.0-beta.12"
+    leaflet "^1.9.4"
+
+"@allmaps/render@^1.0.0-beta.61":
+  version "1.0.0-beta.61"
+  resolved "https://registry.yarnpkg.com/@allmaps/render/-/render-1.0.0-beta.61.tgz#ec155a7de61ad1599eb81af38eff55b5fc711fee"
+  integrity sha512-VPcX1iYeB94PlSitNlGeO7dtc00PydIZwn4FBAFvQWPd6Q8964TMg2ztQXT/bABEZL1q7i04CXjGo4eDmlGQHw==
+  dependencies:
+    "@allmaps/annotation" "^1.0.0-beta.26"
+    "@allmaps/id" "^1.0.0-beta.26"
+    "@allmaps/iiif-parser" "^1.0.0-beta.36"
+    "@allmaps/stdlib" "^1.0.0-beta.27"
+    "@allmaps/transform" "^1.0.0-beta.37"
+    "@allmaps/triangulate" "^1.0.0-beta.19"
+    "@allmaps/types" "^1.0.0-beta.12"
+    "@turf/boolean-point-in-polygon" "^6.5.0"
+    lodash-es "^4.17.21"
+    potpack "^2.0.0"
+    rbush "^3.0.1"
+
+"@allmaps/stdlib@^1.0.0-beta.27":
+  version "1.0.0-beta.27"
+  resolved "https://registry.yarnpkg.com/@allmaps/stdlib/-/stdlib-1.0.0-beta.27.tgz#ea3793ca9ce2254ebaf4c82262f4eec636bb5d52"
+  integrity sha512-ShdfWMNq3wfXCyM5DFsYxUx5gePum3c5GSojSUa6R2W4c5ovDYpe5IsEdqUc+Gg7xRiRLGTule67TtGsVQY7Dg==
+  dependencies:
+    "@allmaps/annotation" "^1.0.0-beta.26"
+    "@allmaps/iiif-parser" "^1.0.0-beta.36"
+    "@allmaps/types" "^1.0.0-beta.12"
+    "@placemarkio/geojson-rewind" "^1.0.2"
+    svg-parser "^2.0.4"
+
+"@allmaps/transform@^1.0.0-beta.37":
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/@allmaps/transform/-/transform-1.0.0-beta.37.tgz#0abc65985e5a44bc8d8ba63152548b3043c3bdba"
+  integrity sha512-vyyPO18FlC1gKaJ+ZRjUPxTop8r3LMXIjHOcJ7Jc5ZaPp6ugdRBQh3u2GuucvRcklsZotjKQ+cZ4XCCsCRYUCg==
+  dependencies:
+    "@allmaps/stdlib" "^1.0.0-beta.27"
+    "@turf/distance" "^6.3.0"
+    "@turf/midpoint" "^6.3.0"
+    ml-matrix "^6.11.0"
+
+"@allmaps/triangulate@^1.0.0-beta.19":
+  version "1.0.0-beta.19"
+  resolved "https://registry.yarnpkg.com/@allmaps/triangulate/-/triangulate-1.0.0-beta.19.tgz#7ff288d056a119f9ad08559c4ea3d643b7cafa17"
+  integrity sha512-y+R9dGKmpWriYNkp251I4fFAfYWg991KktLHD21iKLR56NptMA/ZbrFCSAHghoQq6beGs+54PQV1z79NF/WBqw==
+  dependencies:
+    "@allmaps/stdlib" "^1.0.0-beta.27"
+    "@allmaps/types" "^1.0.0-beta.12"
+    poly2tri "^1.5.0"
+    robust-point-in-polygon "^1.0.3"
+
+"@allmaps/types@^1.0.0-beta.12":
+  version "1.0.0-beta.12"
+  resolved "https://registry.yarnpkg.com/@allmaps/types/-/types-1.0.0-beta.12.tgz#d61b1d5fe0bb9278e6939ed9e0eed285d6f6c7a9"
+  integrity sha512-8avn1itc/46DRSaOJFaOiPltGwdqTdp4PFR2FKAxWCp8DuADGwleJKh4f+5dhoePdFasLNMJAPnyGqISpctXjw==
+
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.5", "@babel/runtime@^7.9.2":
   version "7.24.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.5.tgz#230946857c053a36ccc66e1dd03b17dd0c4ed02c"
@@ -246,6 +333,11 @@
   version "3.8.7"
   resolved "https://registry.yarnpkg.com/@petamoriken/float16/-/float16-3.8.7.tgz#16073fb1b9867eaa5b254573484d09100700aaa4"
   integrity sha512-/Ri4xDDpe12NT6Ex/DRgHzLlobiQXEW/hmG08w1wj/YU7hLemk97c+zHQFp0iZQ9r7YqgLEXZR2sls4HxBf9NA==
+
+"@placemarkio/geojson-rewind@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@placemarkio/geojson-rewind/-/geojson-rewind-1.0.2.tgz#1eba1ce519ba796d1e46c22140dc6ea5157e5ac3"
+  integrity sha512-ulBdZOCvKlUIe9v+/PDVfe4wDvfkJRzRXstGEHbAJGiUN8IDYw3wD3156DcN/rO9DiHfjcF8KUQlQ7iiMd+rrA==
 
 "@radix-ui/number@1.0.1":
   version "1.0.1"
@@ -726,6 +818,60 @@
   resolved "https://registry.yarnpkg.com/@stitches/react/-/react-1.2.8.tgz#954f8008be8d9c65c4e58efa0937f32388ce3a38"
   integrity sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==
 
+"@turf/bearing@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-6.5.0.tgz#462a053c6c644434bdb636b39f8f43fb0cd857b0"
+  integrity sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/boolean-point-in-polygon@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz#6d2e9c89de4cd2e4365004c1e51490b7795a63cf"
+  integrity sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/destination@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/destination/-/destination-6.5.0.tgz#30a84702f9677d076130e0440d3223ae503fdae1"
+  integrity sha512-4cnWQlNC8d1tItOz9B4pmJdWpXqS0vEvv65bI/Pj/genJnsL7evI0/Xw42RvEGROS481MPiU80xzvwxEvhQiMQ==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/distance@^6.3.0", "@turf/distance@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.5.0.tgz#21f04d5f86e864d54e2abde16f35c15b4f36149a"
+  integrity sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/helpers@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.5.0.tgz#f79af094bd6b8ce7ed2bd3e089a8493ee6cae82e"
+  integrity sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==
+
+"@turf/invariant@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.5.0.tgz#970afc988023e39c7ccab2341bd06979ddc7463f"
+  integrity sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
+"@turf/midpoint@^6.3.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/midpoint/-/midpoint-6.5.0.tgz#5f9428959309feccaf3f55873a8de70d4121bdce"
+  integrity sha512-MyTzV44IwmVI6ec9fB2OgZ53JGNlgOpaYl9ArKoF49rXpL84F9rNATndbe0+MQIhdkw8IlzA6xVP4lZzfMNVCw==
+  dependencies:
+    "@turf/bearing" "^6.5.0"
+    "@turf/destination" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+
 "@types/debug@^4.0.0":
   version "4.1.12"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.12.tgz#a155f21690871953410df4b6b6f53187f0500917"
@@ -788,6 +934,15 @@ bail@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
   integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
+
+blacklight-allmaps@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/blacklight-allmaps/-/blacklight-allmaps-0.3.1.tgz#14f0a7965ef203c07fcb713f42a5c7ccb2914cd0"
+  integrity sha512-R+bJ+xgmhREHd4dinwJIZrh/4bfg9x8HbCxgjZQpRQHoJQIsDvSj17h1AwBr2OqFDP0lXOXOnOUd7NYhoiLtlg==
+  dependencies:
+    "@allmaps/leaflet" "^1.0.0-beta.33"
+    leaflet "^1.9.4"
+    leaflet-fullscreen "^1.0.2"
 
 braces@^3.0.2:
   version "3.0.2"
@@ -1160,6 +1315,11 @@ invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
+is-any-array@^2.0.0, is-any-array@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-any-array/-/is-any-array-2.0.1.tgz#9233242a9c098220290aa2ec28f82ca7fa79899e"
+  integrity sha512-UtilS7hLRu++wb/WBAw9bNuP1Eg04Ivn1vERJck8zJthEvXCBEBpGR/33u/xLKWEQf95803oalHrVDptcAvFdQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -1192,10 +1352,25 @@ is-plain-object@^5.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+leaflet-fullscreen@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/leaflet-fullscreen/-/leaflet-fullscreen-1.0.2.tgz#09c61c4bac45f63b2ee126afd87e5cd97650fc1b"
+  integrity sha512-1Yxm8RZg6KlKX25+hbP2H/wnOAphH7hFcvuADJFb4QZTN7uOSN9Hsci5EZpow8vtNej9OGzu59Jxmn+0qKOO9Q==
+
+leaflet@^1.9.4:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.9.4.tgz#23fae724e282fa25745aff82ca4d394748db7d8d"
+  integrity sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==
+
 lerc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lerc/-/lerc-3.0.0.tgz#36f36fbd4ba46f0abf4833799fff2e7d6865f5cb"
   integrity sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 longest-streak@^3.0.0:
   version "3.1.0"
@@ -1642,6 +1817,37 @@ mitt@^3.0.0:
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
+ml-array-max@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/ml-array-max/-/ml-array-max-1.2.4.tgz#2373e2b7e51c8807e456cc0ef364c5863713623b"
+  integrity sha512-BlEeg80jI0tW6WaPyGxf5Sa4sqvcyY6lbSn5Vcv44lp1I2GR6AWojfUvLnGTNsIXrZ8uqWmo8VcG1WpkI2ONMQ==
+  dependencies:
+    is-any-array "^2.0.0"
+
+ml-array-min@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/ml-array-min/-/ml-array-min-1.2.3.tgz#662f027c400105816b849cc3cd786915d0801495"
+  integrity sha512-VcZ5f3VZ1iihtrGvgfh/q0XlMobG6GQ8FsNyQXD3T+IlstDv85g8kfV0xUG1QPRO/t21aukaJowDzMTc7j5V6Q==
+  dependencies:
+    is-any-array "^2.0.0"
+
+ml-array-rescale@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/ml-array-rescale/-/ml-array-rescale-1.3.7.tgz#c4d129320d113a732e62dd963dc1695bba9a5340"
+  integrity sha512-48NGChTouvEo9KBctDfHC3udWnQKNKEWN0ziELvY3KG25GR5cA8K8wNVzracsqSW1QEkAXjTNx+ycgAv06/1mQ==
+  dependencies:
+    is-any-array "^2.0.0"
+    ml-array-max "^1.2.4"
+    ml-array-min "^1.2.3"
+
+ml-matrix@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/ml-matrix/-/ml-matrix-6.11.0.tgz#3cf2260ef04cbb8e0e0425e71d200f5cbcf82772"
+  integrity sha512-7jr9NmFRkaUxbKslfRu3aZOjJd2LkSitCGv+QH9PF0eJoEG7jIpjXra1Vw8/kgao8+kHCSsJONG6vfWmXQ+/Eg==
+  dependencies:
+    is-any-array "^2.0.1"
+    ml-array-rescale "^1.3.7"
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -1747,6 +1953,11 @@ pmtiles@2.11.0:
   dependencies:
     fflate "^0.8.0"
 
+poly2tri@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/poly2tri/-/poly2tri-1.5.0.tgz#db8dfb8cf36ddc6066bcc02ab448aa05617cf22c"
+  integrity sha512-5yACqznqRrlFA9RhdWyD2blNPVhlB3qK+iRYJCfHtJGINb+XNBgKTw+pJOsJZ+oaGxFsIyFmOVapuREHnRhXPg==
+
 postcss@^8.3.11, postcss@^8.4.38:
   version "8.4.38"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.38.tgz#b387d533baf2054288e337066d81c6bee9db9e0e"
@@ -1755,6 +1966,11 @@ postcss@^8.3.11, postcss@^8.4.38:
     nanoid "^3.3.7"
     picocolors "^1.0.0"
     source-map-js "^1.2.0"
+
+potpack@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/potpack/-/potpack-2.0.0.tgz#61f4dd2dc4b3d5e996e3698c0ec9426d0e169104"
+  integrity sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==
 
 property-information@^6.0.0:
   version "6.5.0"
@@ -1930,6 +2146,41 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+robust-orientation@^1.0.2:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/robust-orientation/-/robust-orientation-1.2.1.tgz#f6c2b00a5df5f1cb9597be63a45190f273899361"
+  integrity sha512-FuTptgKwY6iNuU15nrIJDLjXzCChWB+T4AvksRtwPS/WZ3HuP1CElCm1t+OBfgQKfWbtZIawip+61k7+buRKAg==
+  dependencies:
+    robust-scale "^1.0.2"
+    robust-subtract "^1.0.0"
+    robust-sum "^1.0.0"
+    two-product "^1.0.2"
+
+robust-point-in-polygon@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/robust-point-in-polygon/-/robust-point-in-polygon-1.0.3.tgz#ea68f025a44dfe6aede80f0863788705cf547ec4"
+  integrity sha512-pPzz7AevOOcPYnFv4Vs5L0C7BKOq6C/TfAw5EUE58CylbjGiPyMjAnPLzzSuPZ2zftUGwWbmLWPOjPOz61tAcA==
+  dependencies:
+    robust-orientation "^1.0.2"
+
+robust-scale@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/robust-scale/-/robust-scale-1.0.2.tgz#775132ed09542d028e58b2cc79c06290bcf78c32"
+  integrity sha512-jBR91a/vomMAzazwpsPTPeuTPPmWBacwA+WYGNKcRGSh6xweuQ2ZbjRZ4v792/bZOhRKXRiQH0F48AvuajY0tQ==
+  dependencies:
+    two-product "^1.0.2"
+    two-sum "^1.0.0"
+
+robust-subtract@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/robust-subtract/-/robust-subtract-1.0.0.tgz#e0b164e1ed8ba4e3a5dda45a12038348dbed3e9a"
+  integrity sha512-xhKUno+Rl+trmxAIVwjQMiVdpF5llxytozXJOdoT4eTIqmqsndQqFb1A0oiW3sZGlhMRhOi6pAD4MF1YYW6o/A==
+
+robust-sum@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/robust-sum/-/robust-sum-1.0.0.tgz#16646e525292b4d25d82757a286955e0bbfa53d9"
+  integrity sha512-AvLExwpaqUqD1uwLU6MwzzfRdaI6VEZsyvQ3IAQ0ZJ08v1H+DTyqskrf2ZJyh0BDduFVLN7H04Zmc+qTiahhAw==
+
 rollup-plugin-gzip@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-gzip/-/rollup-plugin-gzip-3.1.2.tgz#248267c09b23a7a48291625cf668d5511c517c36"
@@ -2019,6 +2270,11 @@ svg-arc-to-cubic-bezier@^3.2.0:
   resolved "https://registry.yarnpkg.com/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz#390c450035ae1c4a0104d90650304c3bc814abe6"
   integrity sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==
 
+svg-parser@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
+  integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
+
 swiper@^9.4.1:
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/swiper/-/swiper-9.4.1.tgz#2f48bcd6ab4b4fcf4ae93eaee53980531d42fd42"
@@ -2052,6 +2308,16 @@ tslib@^2.0.0, tslib@^2.1.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+two-product@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/two-product/-/two-product-1.0.2.tgz#67d95d4b257a921e2cb4bd7af9511f9088522eaa"
+  integrity sha512-vOyrqmeYvzjToVM08iU52OFocWT6eB/I5LUWYnxeAPGXAhAxXYU/Yr/R2uY5/5n4bvJQL9AQulIuxpIsMoT8XQ==
+
+two-sum@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/two-sum/-/two-sum-1.0.0.tgz#31d3f32239e4f731eca9df9155e2b297f008ab64"
+  integrity sha512-phP48e8AawgsNUjEY2WvoIWqdie8PoiDZGxTDv70LDr01uX5wLEQbOgSP7Z/B6+SW5oLtbe8qaYX2fKJs3CGTw==
 
 typesafe-actions@^5.1.0:
   version "5.1.0"
@@ -2235,6 +2501,11 @@ xml-utils@^1.0.2:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/xml-utils/-/xml-utils-1.8.0.tgz#dd9baa161012849b97703d8423d09d9d815a5910"
   integrity sha512-1TY5yLw8DApowZAUsWCniNr8HH6Ebt6O7UQvmIwziGKwUNsQx6e+4NkfOvCfnqmYIcPjCeoI6dh1JenPJ9a1hQ==
+
+zod@^3.22.4:
+  version "3.23.8"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
 
 zstddec@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This PR adds the [blacklight_allmaps](https://rubygems.org/gems/blacklight_allmaps) gem to the application and ran the blacklight_allmaps generator.

### Rake Tasks

Included with Blacklight::Allmaps are these Rake tasks to harvest, index, and facet georeferenced map data in GeoBlacklight:

Harvest fixtures from Blacklight::Allmaps

```bash
SOLR_URL=http://localhost:54701/solr/blacklight-core-dev LIGHT=geoblacklight bin/rails blacklight_allmaps:index:gbl_fixtures
```

Harvest IIIF Annotations

```bash
bin/rails blacklight_allmaps:sidecars:harvest:allmaps
```

Populate the Georeferenced Facet

```bash
bin/rails blacklight_allmaps:index:georeferenced_facet
```

### Example item

http://localhost:3000/catalog/p16022coll230:360

![Screenshot 2024-05-14 at 11 46 33 AM](https://github.com/ewlarson/gbl-dev/assets/69827/73800da7-01fc-4e75-954c-f643c6bcfbf0)
