### PR TITLE
Add: geoblacklight_sidecar_images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,5 @@ group :development, :test do
 end
 
 gem "blacklight_allmaps", "~> 0.4.0"
+gem "geoblacklight_sidecar_images", git: "https://github.com/geoblacklight/geoblacklight_sidecar_images.git", branch: "feature/rails-7.1"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+GIT
+  remote: https://github.com/geoblacklight/geoblacklight_sidecar_images.git
+  revision: ba9b24b24ea4ec61eada2db57407e8a19902a380
+  branch: feature/rails-7.1
+  specs:
+    geoblacklight_sidecar_images (1.0.0)
+      faraday (>= 2.0)
+      geoblacklight (~> 4.0)
+      image_processing (~> 1.6)
+      mimemagic (~> 0.3)
+      mini_magick (~> 4.9.4)
+      rails (>= 5.2, < 8.0)
+      statesman (>= 3.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -204,6 +218,9 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (2.0.1)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -250,6 +267,10 @@ GEM
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0507)
+    mimemagic (0.4.3)
+      nokogiri (~> 1)
+      rake
+    mini_magick (4.9.5)
     mini_mime (1.1.5)
     mini_portile2 (2.8.6)
     minitar (0.9)
@@ -351,6 +372,8 @@ GEM
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.1)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     sanitize (6.1.0)
       crass (~> 1.0.2)
@@ -385,6 +408,7 @@ GEM
       mini_portile2 (~> 2.8.0)
     sqlite3 (1.7.3-aarch64-linux)
     sqlite3 (1.7.3-x86_64-linux)
+    statesman (12.1.0)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
@@ -445,6 +469,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.8)
   geoblacklight (~> 4.0)
+  geoblacklight_sidecar_images!
   importmap-rails
   jbuilder
   jquery-rails

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 * GeoBlacklight v4.4
 * BlacklightLando v0.3.0
 * Blacklight::Allmaps v0.4.0
+* GeoBlacklight Sidecar Images v1.0.0
 
 ### Steps
 
@@ -21,7 +22,7 @@ cd gbl-dev
 lando start
 ```
 
-[Solr running at http://localhost:54701](http://localhost:54701)
+[View Solr](http://localhost:54701)
 
 #### 3. Start Rails
 
@@ -29,7 +30,7 @@ lando start
 bin/rails s
 ```
 
-[Rails running at http://localhost:3000](http://localhost:3000)
+[View Rails App](http://localhost:3000)
 
 #### 4. Harvest GeoBlacklight Docs
 
@@ -59,3 +60,14 @@ Populate the Georeferenced Facet
 bin/rails blacklight_allmaps:index:georeferenced_facet
 ```
 
+[Allmaps example](http://localhost:3000/catalog/p16022coll230:360)
+
+#### 5. GeoBlacklight Sidecar Images
+
+Harvest Thumbnails
+
+```bash
+bin/rails gblsci:images:harvest_all
+```
+
+[Thumbnails in search results](http://localhost:3000/?search_field=all_fields)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,4 +2,4 @@
 @import 'bootstrap';
 @import 'blacklight';
 @import 'geoblacklight';
-@import 'blacklight/allmaps/base';
+@import 'geoblacklight_sidecar_images/gblsci';@import 'blacklight/allmaps/base';

--- a/app/helpers/blacklight/layout_helper_behavior.rb
+++ b/app/helpers/blacklight/layout_helper_behavior.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+# Methods added to this helper will be available to all templates in the hosting
+# application
+module Blacklight
+  # A module for useful methods used in layout configuration
+  module LayoutHelperBehavior
+    ##
+    # Classes added to a document's show content div
+    # @return [String]
+    def show_content_classes
+      "#{main_content_classes} show-document"
+    end
+
+    ##
+    # Attributes to add to the <html> tag (e.g. lang and dir)
+    # @return [Hash]
+    def html_tag_attributes
+      {lang: I18n.locale}
+    end
+
+    ##
+    # Classes added to a document's sidebar div
+    # @return [String]
+    def show_sidebar_classes
+      sidebar_classes
+    end
+
+    ##
+    # Classes used for sizing the main content of a Blacklight page
+    # @return [String]
+    def main_content_classes
+      "col-lg-9"
+    end
+
+    ##
+    # Classes used for sizing the sidebar content of a Blacklight page
+    # @return [String]
+    def sidebar_classes
+      "page-sidebar col-lg-3"
+    end
+
+    ##
+    # Class used for specifying main layout container classes. Can be
+    # overwritten to return 'container-fluid' for Bootstrap full-width layout
+    # @return [String]
+    def container_classes
+      "container-fluid"
+    end
+
+    ##
+    # Render "document actions" area for navigation header
+    # (normally renders "Saved Searches", "History", "Bookmarks")
+    # These things are added by add_nav_action
+    #
+    # @param [Hash] options
+    # @return [String]
+    def render_nav_actions(options = {}, &)
+      render_filtered_partials(blacklight_config.navbar.partials, options, &)
+    end
+
+    ##
+    # Open Search discovery tag for HTML <head> links
+    # @return [String]
+    def opensearch_description_tag title, href
+      tag :link, href: href, title: title, type: "application/opensearchdescription+xml", rel: "search"
+    end
+
+    ##
+    # Get the page's HTML title
+    #
+    # @return [String]
+    def render_page_title
+      (content_for(:page_title) if content_for?(:page_title)) || @page_title || application_name
+    end
+
+    ##
+    # Create <link rel="alternate"> links from a documents dynamically
+    # provided export formats.
+    #
+    # Returns empty string if no links available.
+    #
+    # @param [SolrDocument] document
+    # @param [Hash] options
+    # @option options [Boolean] :unique ensures only one link is output for every
+    #     content type, e.g. as required by atom
+    # @option options [Array<String>] :exclude array of format shortnames to not include in the output
+    # @return [String]
+    def render_link_rel_alternates(document = @document, options = {})
+      return if document.nil?
+
+      document_presenter(document).link_rel_alternates(options)
+    end
+
+    ##
+    # Render classes for the <body> element
+    # @return [String]
+    def render_body_class
+      extra_body_classes.join " "
+    end
+
+    ##
+    # List of classes to be applied to the <body> element
+    # @see render_body_class
+    # @return [Array<String>]
+    def extra_body_classes
+      @extra_body_classes ||= ["blacklight-#{controller.controller_name}", "blacklight-#{[controller.controller_name, controller.action_name].join("-")}"]
+    end
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -4,6 +4,7 @@
 class SolrDocument
   include Blacklight::Solr::Document
  include Geoblacklight::SolrDocument
+ include WmsRewriteConcern
 
   # self.unique_key = 'id'
   self.unique_key = Settings.FIELDS.UNIQUE_KEY
@@ -34,4 +35,18 @@ class SolrDocument
 
     sidecar
   end
+        def sidecar
+          # Find or create, and set version
+          sidecar = SolrDocumentSidecar.where(
+            document_id: id,
+            document_type: self.class.to_s
+          ).first_or_create do |sc|
+            sc.version = self._source["_version_"]
+          end
+
+          sidecar.version = self._source["_version_"]
+          sidecar.save
+
+          sidecar
+        end
 end

--- a/app/views/catalog/_index_split_default.html.erb
+++ b/app/views/catalog/_index_split_default.html.erb
@@ -1,0 +1,35 @@
+<% # header bar for doc items in index view -%>
+<%= content_tag :div, class: 'documentHeader row mb-4', data: { layer_id: document.id, geom: document.geometry.geojson } do %>
+  <div class='col-md-12'>
+    <div class='row'>
+      <div class='col-2 thumbnail'>
+        <% if document.sidecar.image.attached? %>
+          <% if document.sidecar.image.variable? %>
+            <%= image_tag document.sidecar.image.variant(resize_to_fit: [200, 200]) %>
+          <% else %>
+            <%= image_tag document.sidecar.image %>
+          <% end %>
+        <% else %>
+          <span class="icon square" title="<%=document[Settings.FIELDS.RESOURCE_CLASS]%>">
+            <%= geoblacklight_icon(document[Settings.FIELDS.RESOURCE_CLASS].first) %>
+          </span>
+        <% end %>
+      </div>
+      <div class='col-9'>
+        <h3 class="index_title text-span">
+          <% counter = document_counter_with_offset(document_counter) %>
+          <span class="document-counter">
+            <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
+          </span>
+          <%= link_to_document document, counter: counter, itemprop: "name" %>
+        </h3>
+        <small>
+          <div class='status-icons'>
+            <%= render partial: 'header_icons', locals: { document: document } %>
+          </div>
+          <%= geoblacklight_present(:index_fields_display, document) %>
+        </small>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,8 @@ module GblDev
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Image Processing
+    config.active_storage.variant_processor = :vips
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,4 +74,5 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+        config.active_job.queue_adapter = :inline
 end

--- a/config/initializers/statesman.rb
+++ b/config/initializers/statesman.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "statesman"
+
+Statesman.configure do
+  storage_adapter(Statesman::Adapters::ActiveRecord)
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -89,7 +89,11 @@ FIELDS:
 
 # Institution deployed at
 INSTITUTION: 'Stanford'
-
+INSTITUTION_LOCAL_NAME: 'Princeton'
+INSTITUTION_GEOSERVER_URL: 'https://geoserver.princeton.edu'
+PROXY_GEOSERVER_URL: 'http://localhost:3000'
+PROXY_GEOSERVER_AUTH: 'Basic base64encodedusername:password'
+GBLSI_THUMBNAIL_FIELD: 'thumbnail_path_ss'
 # Metadata shown in tool panel
 METADATA_SHOWN:
   - 'mods'

--- a/db/migrate/20240514194850_create_solr_document_sidecars.geoblacklight_sidecar_images.rb
+++ b/db/migrate/20240514194850_create_solr_document_sidecars.geoblacklight_sidecar_images.rb
@@ -1,0 +1,15 @@
+# This migration comes from geoblacklight_sidecar_images (originally 20180118203155)
+class CreateSolrDocumentSidecars < ActiveRecord::Migration[5.2]
+  def change
+    create_table :solr_document_sidecars do |t|
+      t.string "document_id"
+      t.string "document_type"
+      t.string "image"
+      t.integer "version", limit: 8
+
+      t.index ["document_type", "document_id"], name: "sidecars_solr_document"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240514194851_create_sidecar_image_transitions.geoblacklight_sidecar_images.rb
+++ b/db/migrate/20240514194851_create_sidecar_image_transitions.geoblacklight_sidecar_images.rb
@@ -1,0 +1,30 @@
+# This migration comes from geoblacklight_sidecar_images (originally 20180118203519)
+class CreateSidecarImageTransitions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sidecar_image_transitions do |t|
+      t.string :to_state, null: false
+      t.text :metadata
+      t.integer :sort_key, null: false
+      t.bigint :solr_document_sidecar_id, null: false
+      t.boolean :most_recent
+
+      # If you decide not to include an updated timestamp column in your transition
+      # table, you'll need to configure the `updated_timestamp_column` setting in your
+      # migration class.
+      t.timestamps null: false
+    end
+
+    # Foreign keys are optional, but highly recommended
+    add_foreign_key :sidecar_image_transitions, :solr_document_sidecars
+
+    add_index(:sidecar_image_transitions,
+      [:solr_document_sidecar_id, :sort_key],
+      unique: true,
+      name: "index_sidecar_image_transitions_parent_sort")
+    add_index(:sidecar_image_transitions,
+      [:solr_document_sidecar_id, :most_recent],
+      unique: true,
+
+      name: "index_sidecar_image_transitions_parent_most_recent")
+  end
+end

--- a/db/migrate/20240514194856_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20240514194856_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_14_161028) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_14_194856) do
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "blacklight_allmaps_sidecars", force: :cascade do |t|
     t.string "solr_document_id"
     t.string "document_type", default: "SolrDocument"
@@ -48,6 +76,28 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_161028) do
     t.index ["user_id"], name: "index_searches_on_user_id"
   end
 
+  create_table "sidecar_image_transitions", force: :cascade do |t|
+    t.string "to_state", null: false
+    t.text "metadata"
+    t.integer "sort_key", null: false
+    t.bigint "solr_document_sidecar_id", null: false
+    t.boolean "most_recent"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["solr_document_sidecar_id", "most_recent"], name: "index_sidecar_image_transitions_parent_most_recent", unique: true
+    t.index ["solr_document_sidecar_id", "sort_key"], name: "index_sidecar_image_transitions_parent_sort", unique: true
+  end
+
+  create_table "solr_document_sidecars", force: :cascade do |t|
+    t.string "document_id"
+    t.string "document_type"
+    t.string "image"
+    t.integer "version", limit: 8
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["document_type", "document_id"], name: "sidecars_solr_document"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -61,4 +111,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_161028) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "sidecar_image_transitions", "solr_document_sidecars"
 end

--- a/solr/geoblacklight/example_docs/README.md
+++ b/solr/geoblacklight/example_docs/README.md
@@ -1,0 +1,40 @@
+# Listing of GeoBlacklight .json test documents
+
+If you add a new document, please add it to the table below, and indicate its purpose.
+
+| document | purpose |
+| -------- | ------- |
+| actual-papermap1 |Nondigitized paper map with a link to a library catalog|
+| actual-point1 |Point dataset with WMS and WFS|
+| actual-polygon1 |Polygon dataset (no direct download) with WFS, WMS, and FGDC metadata as XML|
+| actual-raster1 |Restricted raster layer with WMS and metadata in MODS and ISO 19139|
+| baruch_ancestor1 |SQLite Database with documentation download. Referenced as parent|
+| baruch_ancestor2 |Geodatabase with documentation download. Referenced as parent|
+| baruch_documentation_download |Point dataset with WMS and WFS, documentation download, and two parent records|
+| bbox-spans-180 |Scanned map with IIIF and direct TIFF download that spans across the 180th meridian|
+| cornell_html_metadata |Point dataset with WMS, WFS, direct download, and FGDC metadata XML and HTML|
+| esri-dynamic-layer-single-layer |ArcGIS Dynamic Map Layer with single layer indicated|
+| esri-feature-layer |ArcGIS Feature Layer - point dataset|
+| esri-image-map-layer |ArcGIS Image Map Layer with GeoTIFF direct download|
+| esri-tiled_map_layer |ArcGIS tiled map layer|
+| esri-wms-layer |Dataset with ArcGIS Dynamic Map Layer, ArcGIS WMS, and direct download|
+| harvard_raster |Raster with WMS and Harvard style download function|
+| iiif-eastern-hemisphere |Eastern hemisphere scanned map with IIIF and direct TIFF download|
+| index_map_point | GeoJSON index map of points |
+| index_map_polygon | GeoJSON index map of polygons, with a downloadUrl for the index itself |
+| index_map_polygon-no-downloadurl | GeoJSON index map of polygons, but lacking a downloadUrl for the index itself |
+| index-map-stanford | old-style (pre-GeoJSON) index map of rectangular polygons |
+| no_spatial |File without geometry type or solr_geometry (will cause error)|
+| princeton-child1.json | Child record for testing the `suppressed_b` property |
+| princeton-child2.json | Child record for testing the `suppressed_b` property |
+| princeton-child3.json | Child record for testing the `suppressed_b` property |
+| princeton-child4.json | Child record for testing the `suppressed_b` property |
+| princeton-parent.json | Parent record for testing the `suppressed_b` property |
+| public_direct_download | includes a tentative `dcat_distribution_sm` property |
+| public_iiif_princeton |Scanned map with IIIF|
+| public_polygon_mit |Polygon shapefile with WMS and WFS|
+| restricted-line |Restricted line layer with WFS, WMS and metadata in MODS and ISO 19139|
+| umn_metro_result1.json |Bounding box of metropolitan area and ArcGIS Dynamic Map Layer|
+| umn_state_result1.json |Bounding box of state area and static image in references|
+| umn_state_result2.json |Bounding box of state area and raster download|
+| uva_slug_colon.json | Multipoint dataset with WMS and WFS and a colon in the slug and layer ID |

--- a/solr/geoblacklight/example_docs/actual-polygon1.json
+++ b/solr/geoblacklight/example_docs/actual-polygon1.json
@@ -1,0 +1,38 @@
+{
+  "id": "tufts-cambridgegrid100-04",
+  "dct_identifier_sm": [
+    "urn:geodata.tufts.edu:Tufts.CambridgeGrid100_04"
+  ],
+  "dct_title_s": "100 Foot Grid Cambridge MA 2004",
+  "dct_description_sm": [
+    "This polygon dataset is a 100 foot grid overlay for Cambridge, MA."
+  ],
+  "dct_language_sm": [
+    "English"
+  ],
+  "dct_publisher_sm": [
+    "Cambridge (Mass.) Geographic Information Systems"
+  ],
+  "schema_provider_s": "Tufts",
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "gbl_resourceType_sm": [
+    "Polygon data"
+  ],
+  "dct_temporal_sm": [
+    "2004"
+  ],
+  "dct_issued_s": "2005",
+  "gbl_indexYear_im": [
+    2004
+  ],
+  "locn_geometry": "ENVELOPE(-71.163984, -71.052581, 42.408316, 42.34757)",
+  "dcat_bbox": "ENVELOPE(-71.163984, -71.052581, 42.408316, 42.34757)",
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "Shapefile",
+  "gbl_wxsIdentifier_s": "sde:GISPORTAL.GISOWNER01.CAMBRIDGEGRID100_04",
+  "dct_references_s": "{\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"http://geoserver01.uit.tufts.edu/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"http://geoserver01.uit.tufts.edu/wms\",\"http://www.opengis.net/cat/csw/csdgm\":\"https://raw.githubusercontent.com/OpenGeoMetadata/edu.tufts/master/165/242/110/132/fgdc.xml\",\"http://schema.org/downloadUrl\":[]}",
+  "gbl_mdModified_dt": "2014-12-04T21:33:07Z",
+  "gbl_mdVersion_s": "Aardvark"
+}

--- a/solr/geoblacklight/example_docs/esri-dynamic-layer-all-layers.json
+++ b/solr/geoblacklight/example_docs/esri-dynamic-layer-all-layers.json
@@ -1,0 +1,47 @@
+{
+  "id": "90f14ff4-1359-4beb-b931-5cb41d20ab90",
+  "dct_identifier_sm": [
+    "90f14ff4-1359-4beb-b931-5cb41d20ab90"
+  ],
+  "dct_title_s": "Glacial Boundaries: Illinois, 1998",
+  "dct_description_sm": [
+    "Glacial boundary lines representing the extent of glaciation for major glacial episodes in Illinois. Data originally from Quaternary Deposits in Illinois map by Lineback (1979) and modified according to the reclassification by Hansel and Johnson, ISGS Bulletin 104 (1996). Attribute items include glacial episode identifier. ISGS, 1984 (revised 1998)."
+  ],
+  "dct_language_sm": [
+    "English"
+  ],
+  "dct_creator_sm": [
+    "Illinois State Geological Survey"
+  ],
+  "dct_publisher_sm": [
+    "Illinois State Geological Survey"
+  ],
+  "schema_provider_s": "Illinois",
+  "gbl_resourceClass_sm": [
+    "EDIT ME -- this record had dc_type_s = Dataset"
+  ],
+  "gbl_resourceType_sm": [
+    "Polygon data"
+  ],
+  "dct_subject_sm": [
+    "Geoscientific Information"
+  ],
+  "dct_temporal_sm": [
+    "1998"
+  ],
+  "dct_issued_s": "1998",
+  "gbl_indexYear_im": [
+    1998
+  ],
+  "dct_spatial_sm": [
+    "Illinois, United States"
+  ],
+  "locn_geometry": "ENVELOPE(-91.513518, -87.495214, 42.508348,  36.969972)",
+  "dcat_bbox": "ENVELOPE(-91.513518, -87.495214, 42.508348,  36.969972)",
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "Shapefile",
+  "dct_references_s": "{\"urn:x-esri:serviceType:ArcGIS#DynamicMapLayer\":\"http://data.isgs.illinois.edu/arcgis/rest/services/Geology/Glacial_Boundaries/MapServer\",\"http://schema.org/url\":\"https://clearinghouse.isgs.illinois.edu/data/geology/glacial-boundaries\",\"http://schema.org/downloadUrl\":[{\"label\":\"Shapefile\",\"url\":\"https://clearinghouse.isgs.illinois.edu/sites/clearinghouse.isgs/files/Clearinghouse/data/ISGS/Geology/zips/IL_Glacial_Bndys_Py.zip\"}]}",
+  "gbl_mdModified_dt": "2018-08-02T17:00:40Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "dct_isPartOf_sm": "illinois-collection-illinois-geospatial-data-clearinghouse"
+}

--- a/solr/geoblacklight/example_docs/esri-image-map-layer.json
+++ b/solr/geoblacklight/example_docs/esri-image-map-layer.json
@@ -1,0 +1,52 @@
+{
+  "id": "32653ed6-8d83-4692-8a06-bf13ffe2c018",
+  "dct_identifier_sm": [
+    "32653ed6-8d83-4692-8a06-bf13ffe2c018"
+  ],
+  "dct_title_s": "Wabash Topo (27): Indiana, 1929",
+  "dct_description_sm": [
+    "The maps represented here are on tiff files owned by EAS library. The topos were scanned in color and are up to 550MB each. These images can be viewed and performed in the using either ArcGIS Desktop or QGIS (user choice), referencing against a number of known mapsets like the 2005 Indiana Orthophoto setand USGS DRGs. The geographic coordinate system reference of the maps included are applied in GCS_WGS_1984."
+  ],
+  "dct_language_sm": [
+    "English"
+  ],
+  "dct_publisher_sm": [
+    "Purdue University Libraries"
+  ],
+  "schema_provider_s": "Purdue",
+  "gbl_resourceClass_sm": [
+    "EDIT ME -- this record had dc_type_s = Image"
+  ],
+  "gbl_resourceType_sm": [
+    "EDIT ME -- this record had layer_geom_type_s = Image"
+  ],
+  "dct_subject_sm": [
+    "Imagery and Base Maps",
+    "Topography"
+  ],
+  "dcat_theme_sm": [
+    "imagery",
+    "elevation"
+  ],
+  "dct_temporal_sm": [
+    "1929"
+  ],
+  "dct_issued_s": "2015-10-31",
+  "gbl_indexYear_im": [
+    1929
+  ],
+  "dct_spatial_sm": [
+    "Indiana, United States"
+  ],
+  "locn_geometry": "ENVELOPE(-87.324704, -87.174404, 40.310695, 40.233691)",
+  "dcat_bbox": "ENVELOPE(-87.324704, -87.174404, 40.310695, 40.233691)",
+  "dct_source_sm": [
+    "88cc9b19-3294-4da9-9edd-775c81fb1c59"
+  ],
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "GeoTIFF",
+  "dct_references_s": "{\"http://schema.org/url\":\"https://mapsweb.lib.purdue.edu/wabashriver/\",\"http://schema.org/downloadUrl\":[{\"label\":\"GeoTIFF\",\"url\":\"https://mapsweb.lib.purdue.edu/datasets/Wabash1929/wabash_topo_27.tif.zip\"}],\"urn:x-esri:serviceType:ArcGIS#ImageMapLayer\":\"https://mapsweb.lib.purdue.edu/arcgis/rest/services/Purdue/wabashtopo/ImageServer\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"http://64.90.181.107/geonetwork/srv/api/records/32653ed6-8d83-4692-8a06-bf13ffe2c018/formatters/xml\"}",
+  "gbl_mdModified_dt": "2018-07-20T18:08:03Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "dct_isPartOf_sm": "purdue-collection-purdue-georeferenced-imagery"
+}

--- a/solr/geoblacklight/example_docs/esri-tiled_map_layer.json
+++ b/solr/geoblacklight/example_docs/esri-tiled_map_layer.json
@@ -1,0 +1,37 @@
+{
+  "id": "esri-tiled-map-layer",
+  "dct_identifier_sm": [
+    "esri-tiled-map-layer"
+  ],
+  "dct_title_s": "Specialty/World_Navigation_Charts (MapServer)",
+  "dct_description_sm": [
+    "This map presents a digital version of the Operational Navigation Charts (ONC) at 1:1,000,000-scale, produced by the US National Geospatial-Intelligence Agency (NGA). The map includes over 200 charts across the world, excluding parts of North America, Europe, Asia, and Oceania where charts are not publicly available. For more information on this map, including the terms of use, visit us online."
+  ],
+  "dct_language_sm": [
+    "English"
+  ],
+  "dct_publisher_sm": [
+    "United States Department of Agriculture, Natural Resources Conservation Service"
+  ],
+  "schema_provider_s": "NYU",
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "gbl_resourceType_sm": [
+    "Raster data"
+  ],
+  "dct_temporal_sm": [
+    "2013"
+  ],
+  "gbl_indexYear_im": [
+    2010
+  ],
+  "locn_geometry": "ENVELOPE(-129.4956, -64.4393, 48.6336, 21.8079)",
+  "dcat_bbox": "ENVELOPE(-129.4956, -64.4393, 48.6336, 21.8079)",
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "GeoTIFF",
+  "gbl_wxsIdentifier_s": "esri-tiled-map-layer",
+  "dct_references_s": "{\"urn:x-esri:serviceType:ArcGIS#TiledMapLayer\":\"https://services.arcgisonline.com/arcgis/rest/services/Specialty/World_Navigation_Charts/MapServer\",\"http://schema.org/downloadUrl\":[]}",
+  "gbl_mdModified_dt": "2015-06-16T00:59:49Z",
+  "gbl_mdVersion_s": "Aardvark"
+}

--- a/solr/geoblacklight/example_docs/placeholder.json
+++ b/solr/geoblacklight/example_docs/placeholder.json
@@ -1,0 +1,38 @@
+{
+  "id": "mit-001145244",
+  "dct_identifier_sm": [
+    "urn:arrowsmith.mit.edu:MIT.001145244"
+  ],
+  "dct_title_s": "1:1 500 000 series [cartographic material] : tectonic map of Britain, Ireland and adjacent areas / British Geological Survey ; Geological Survey of Ireland ; Geological Survey of Northern Ireland.",
+  "dct_description_sm": [
+    "Panel title. Depths shown by isolines. \"Geological map [copyright] NERC 1996.\" Also available on flat sheet. \"Sheet 1\"--on panel. Includes text, notes, organizations' logos, and ancillary map of \"Orogenic terranes of Britain, Ireland and surrounding seas.\""
+  ],
+  "dct_language_sm": [
+    "English"
+  ],
+  "dct_publisher_sm": [
+    "British Geological Survey"
+  ],
+  "schema_provider_s": "MIT",
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "gbl_resourceType_sm": [
+    "EDIT ME -- this record had layer_geom_type_s = Paper Map"
+  ],
+  "dct_temporal_sm": [
+    "1996"
+  ],
+  "dct_issued_s": "2000",
+  "gbl_indexYear_im": [
+    1996
+  ],
+  "locn_geometry": "ENVELOPE(-13.0, 4.0, 62.0, 49.0)",
+  "dcat_bbox": "ENVELOPE(-13.0, 4.0, 62.0, 49.0)",
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "Paper",
+  "gbl_wxsIdentifier_s": "MIT:001145244",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://library.mit.edu/item/001145244\",\"http://schema.org/downloadUrl\":[]}",
+  "gbl_mdModified_dt": "2014-12-04T21:32:59Z",
+  "gbl_mdVersion_s": "Aardvark"
+}

--- a/solr/geoblacklight/example_docs/public_iiif_princeton.json
+++ b/solr/geoblacklight/example_docs/public_iiif_princeton.json
@@ -1,0 +1,51 @@
+{
+  "id": "princeton-02870w62c",
+  "dct_identifier_sm": [
+    "http://arks.princeton.edu/ark:/88435/02870w62c"
+  ],
+  "dct_title_s": "The provinces of New York and New Jersey, with part of Pensilvania, and the Province of Quebec : drawn by Major Holland, Surveyor General, of the Northern District in America. Corrected and improved, from the original materials, by Governr. Pownall, Member of Parliament, 1776",
+  "dct_description_sm": [
+    "Partly colored. Relief shown pictorially. Shows administrative divisions. From Thomas Jefferys's The American atlas, or, A geographical description of the whole continent of America (London : Printed by R. Sayer and Bennett, 1778). Insets: A chart of the mouth of Hudson's River, from Sandy Hook to New York. A plan of the city of New York. Plan of Amboy, with its environs, from an actual survey."
+  ],
+  "dct_language_sm": [
+    "English"
+  ],
+  "dct_creator_sm": [
+    "Rogers, Henry Darwin",
+    "Pownall, Thomas"
+  ],
+  "dct_publisher_sm": [
+    "London, Robt. Sayer & John Bennett"
+  ],
+  "schema_provider_s": "Princeton",
+  "gbl_resourceClass_sm": [
+    "Datasets"
+  ],
+  "gbl_resourceType_sm": [
+    "Raster data"
+  ],
+  "dct_subject_sm": [
+    "New York (State)‒Maps",
+    "New Jersey‒Maps"
+  ],
+  "dct_temporal_sm": [
+    "1778"
+  ],
+  "dct_issued_s": "1778",
+  "gbl_indexYear_im": [
+    1778
+  ],
+  "dct_spatial_sm": [
+    "New York (State)",
+    "New Jersey",
+    "Pennsylvania"
+  ],
+  "locn_geometry": "ENVELOPE(-76.3394, -72.1916, 46.5798, 38.6693)",
+  "dcat_bbox": "ENVELOPE(-76.3394, -72.1916, 46.5798, 38.6693)",
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "Raster",
+  "gbl_wxsIdentifier_s": "02870w62c",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://arks.princeton.edu/ark:/88435/02870w62c\",\"http://schema.org/thumbnailUrl\":\"https://libimages.princeton.edu/loris2/pudl0076%2Fmap_pownall%2F00000001.jp2/full/50,/0/default.jpg\",\"http://iiif.io/api/image\":\"https://libimages.princeton.edu/loris/pudl0076/map_pownall/00000001.jp2/info.json\",\"http://schema.org/downloadUrl\":[]}",
+  "gbl_mdModified_dt": "2014-10-09T18:00:18Z",
+  "gbl_mdVersion_s": "Aardvark"
+}

--- a/solr/geoblacklight/example_docs/umich_iiif_jpg.json
+++ b/solr/geoblacklight/example_docs/umich_iiif_jpg.json
@@ -1,0 +1,51 @@
+{
+  "id": "3ffb1f2e-d617-4361-bc2b-49d9ad270cad",
+  "dct_identifier_sm": [
+    "umich-iiif-jpg-3ffb1f2e-d617-4361-bc2b-49d9ad270cad"
+  ],
+  "dct_title_s": "A new map of America from the latest observations / revis'd by I. Senex.",
+  "dct_description_sm": [
+    "Relief shown pictorially. Dedication in title cartouche to [Henry Bowes Howard,] Earl of Berkshire, deputy earl marshal of England. Shows California as an island. Includes elaborate decorative cartouche in the upper left corner. The cartouche depicts scenes of Native American life, such as battle and food as well. 1 map : outline col. ; 47 x 55 cm. This map is in the public domain. Please attribute access and use of this digitized map to the Stephen S. Clark Library, University of Michigan Library."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "Senex, John, -1740.",
+    "Harris, John, fl. ca.1685-ca. 1720 engraver.",
+    "Senex, John, -1740. A new general atlas.",
+    "Dahl, James, former owner."
+  ],
+  "dct_publisher_sm": [
+    "London : s.n."
+  ],
+  "schema_provider_s": "Michigan",
+  "gbl_resourceClass_sm": [
+    "Imagery"
+  ],
+  "gbl_resourceType_sm": [
+    "EDIT ME -- this record had layer_geom_type_s = Paper Map"
+  ],
+  "dct_temporal_sm": [
+    "ca. 1719"
+  ],
+  "gbl_indexYear_im": [
+    1719
+  ],
+  "dct_spatial_sm": [
+    "Americas"
+  ],
+  "locn_geometry": "ENVELOPE(-179.27, -1.42, 68.65, -60.15)",
+  "dcat_bbox": "ENVELOPE(-179.27, -1.42, 68.65, -60.15)",
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "JPEG",
+  "dct_references_s": "{\"http://schema.org/url\":\"https://quod.lib.umich.edu/c/clark1ic/x-012464989/39015095390558\",\"http://schema.org/downloadUrl\":[{\"label\":\"JPEG\",\"url\":\"https://quod.lib.umich.edu/cgi/i/image/api/image/clark1ic:012464989:39015095390558/full/res:5/0/native.jpg?attachment=1\"}],\"http://iiif.io/api/image\":\"https://quod.lib.umich.edu/cgi/i/image/api/image/clark1ic:012464989:39015095390558/info.json\"}",
+  "gbl_mdModified_dt": "2017-12-11T16:28:21Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "thumbnail_path_ss": "https://quod.lib.umich.edu/cgi/i/image/api/image/clark1ic:012464989:39015095390558/full/res:5/0/native.jpg?attachment=1",
+  "dc_relation_sm": [
+    "http://sws.geonames.org/10861432"
+  ],
+  "centroid_s": "4.25,-90.345",
+  "dct_isPartOf_sm": "michigan-collection-clark-library-map-collections"
+}

--- a/solr/geoblacklight/example_docs/umn_iiif_jpg.json
+++ b/solr/geoblacklight/example_docs/umn_iiif_jpg.json
@@ -1,0 +1,58 @@
+{
+  "id": "83f4648a-125c-4000-a12f-aba2b432e7cd",
+  "dct_identifier_sm": [
+    "minnesota-iiif-jpg-83f4648a-125c-4000-a12f-aba2b432e7cd"
+  ],
+  "dct_title_s": "Bird's eye view of Minneapolis, Minn",
+  "dct_description_sm": [
+    "Cartographic Details: Scale approximately 1:1,341,000. 90 British Miles 69 1/2 to a Degree = 10.8 cm. Third edition. 56 x 83 cm"
+  ],
+  "dct_language_sm": [
+    "English"
+  ],
+  "dct_creator_sm": [
+    "Pezolt, F."
+  ],
+  "dct_publisher_sm": [
+    "A.M. Smith"
+  ],
+  "schema_provider_s": "Minnesota",
+  "gbl_resourceClass_sm": [
+    "Imagery"
+  ],
+  "gbl_resourceType_sm": [
+    "EDIT ME -- this record had layer_geom_type_s = Paper Map"
+  ],
+  "dct_subject_sm": [
+    "Aerial views",
+    "Bird's-eye views"
+  ],
+  "dcat_theme_sm": [
+    "imagery",
+    "biology"
+  ],
+  "dct_temporal_sm": [
+    "1891"
+  ],
+  "dct_issued_s": "1891",
+  "gbl_indexYear_im": [
+    1891
+  ],
+  "dct_spatial_sm": [
+    "Minneapolis, Minnesota, United States",
+    "Minnesota, United States"
+  ],
+  "locn_geometry": "ENVELOPE(-93.2601, -93.2301, 44.98, 44.96)",
+  "dcat_bbox": "ENVELOPE(-93.2601, -93.2301, 44.98, 44.96)",
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "TIFF",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://purl.umn.edu/204328\",\"http://schema.org/downloadUrl\":[{\"label\":\"TIFF\",\"url\":\"https://umedia.lib.umn.edu/sites/default/files/archive/84/image/tiff/1062058.tif\"}],\"http://iiif.io/api/image\":\"https://cdm16022.contentdm.oclc.org/digital/iiif/p16022coll245/889/info.json\"}",
+  "gbl_mdModified_dt": "2017-12-11T12:01:50Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "dc_relation_sm": [
+    "http://sws.geonames.org/5037649",
+    "http://sws.geonames.org/5037779"
+  ],
+  "centroid_s": "44.97,-93.2451",
+  "dct_isPartOf_sm": "minnesota-collection-john-r-borchert-map-library"
+}

--- a/solr/geoblacklight/example_docs/umn_solr_thumb.json
+++ b/solr/geoblacklight/example_docs/umn_solr_thumb.json
@@ -1,0 +1,62 @@
+{
+  "id": "aaf63e35-3d5f-4e62-b59d-377f008e9aad",
+  "dct_identifier_sm": [
+    "aaf63e35-3d5f-4e62-b59d-377f008e9aad"
+  ],
+  "dct_title_s": "Condition map of Minnesota Trunk Highways : a 7,000 mile primary system showing national and state markings",
+  "dct_description_sm": [
+    "Cartographic Details: Scale approximately 1:1,530,000. Description based on: 1932 sheet. Each sheet lists the Commissioner of highways and the Chief Engineer. On verso: Distance tables for various cities in Minnesota."
+  ],
+  "dct_language_sm": [
+    "eng"
+  ],
+  "dct_creator_sm": [
+    "Minnesota. Department of Highways."
+  ],
+  "dct_publisher_sm": [
+    "The Department"
+  ],
+  "schema_provider_s": "Minnesota",
+  "gbl_resourceClass_sm": [
+    "EDIT ME -- this record had dc_type_s = Still image"
+  ],
+  "gbl_resourceType_sm": [
+    "EDIT ME -- this record had layer_geom_type_s = Paper Map"
+  ],
+  "dct_subject_sm": [
+    "Roads -- Minnesota -- Maps",
+    "Minnesota -- Distances -- Tables",
+    "Minnesota -- Maps",
+    "Maps"
+  ],
+  "dcat_theme_sm": [
+    "transportation"
+  ],
+  "dct_temporal_sm": [
+    "1925"
+  ],
+  "dct_issued_s": "1925",
+  "gbl_indexYear_im": [
+    1925
+  ],
+  "dct_spatial_sm": [
+    "Minnesota, United States"
+  ],
+  "locn_geometry": "ENVELOPE(-97.2509765625, -90.9228515625, 49.3787965644, 43.4648808289)",
+  "dcat_bbox": "ENVELOPE(-97.2509765625, -90.9228515625, 49.3787965644, 43.4648808289)",
+  "dct_accessRights_s": "Public",
+  "dct_format_s": "TIFF",
+  "gbl_wxsIdentifier_s": "urn:aaf63e35-3d5f-4e62-b59d-377f008e9aad",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://purl.umn.edu/231125\",\"http://schema.org/downloadUrl\":[{\"label\":\"TIFF\",\"url\":\"https://umedia.lib.umn.edu/sites/default/files/archive/562/image/tiff/1089695.tif\"}],\"http://iiif.io/api/image\":\"https://umedia.lib.umn.edu/fcgi-bin/iipsrv.fcgi?IIIF=sites/default/files/reference/562/image/jp2/1089695.jp2/info.json\"}",
+  "gbl_mdModified_dt": "2017-06-12T13:36:50Z",
+  "gbl_mdVersion_s": "Aardvark",
+  "thumbnail_path_ss": "https://cdm16022.contentdm.oclc.org/utils/getthumbnail/collection/p16022coll206/id/133.jpg",
+  "dc_relation_sm": [
+    "http://sws.geonames.org/5037779/about/rdf"
+  ],
+  "georss_box_s": "43.4648808289 -97.2509765625 49.3787965644 -90.9228515625",
+  "georss_polygon_s": "43.4648808289 -97.2509765625 49.3787965644 -97.2509765625 49.3787965644 -90.9228515625 43.4648808289 -90.9228515625 43.4648808289 -97.2509765625",
+  "timestamp": "2017-06-12T22:01:27.649Z",
+  "centroid_s": "46.42183869665,-94.0869140625",
+  "dct_isPartOf_sm": "minnesota-collection-john-r-borchert-map-library"
+}


### PR DESCRIPTION
This PR adds the [geoblacklight_sidecar_images](https://rubygems.org/gems/geoblacklight_sidecar_images) gem at the `feature/rails-7.1` branch to the application and ran the geoblacklight_sidecar_images generator.

### Rake Tasks

Thumbnails can be harvested via the rake task below:

```bash
bundle exec rake gblsci:images:harvest_all
```

### Thumbnails

http://localhost:3000/?search_field=all_fields

![Screenshot 2024-05-14 at 4 14 34 PM](https://github.com/ewlarson/gbl-dev/assets/69827/a1b2ee70-ae9b-40e6-acd3-c14bed3b9827)

